### PR TITLE
kustomize: improve nginx config

### DIFF
--- a/kustomize/base/default.conf
+++ b/kustomize/base/default.conf
@@ -1,23 +1,18 @@
 server {
-  listen       80;
-  listen  [::]:80;
-  server_name  localhost;
+  listen      80;
+  listen [::]:80;
 
-  root /usr/share/nginx/html;
+  location /.well-known/openpgpkey/ {
+    root /usr/share/nginx/html;
 
-  location / {
-    index  index.html index.htm;
-  }
-
-  location /.well-known/openpgpkey/hu/ {
-    default_type "application/octet-stream";
     add_header Access-Control-Allow-Origin * always;
-  }
 
-  # redirect server error pages to the static page /50x.html
-  #
-  error_page   500 502 503 504  /50x.html;
-  location = /50x.html {
-      root   /usr/share/nginx/html;
+    location ~ /hu/ {
+      default_type "application/octet-stream";
+    }
+
+    location ~ /policy$ {
+      default_type "text/html";
+    }
   }
 }


### PR DESCRIPTION
  - Remove unrequired sections
  - Serve Access-Control-Allow-Origin header for advanced setup
  - Avoid unconditional exposure of /50x.html
  - Don't serve anything outside of openpgpkey well-known directory

Closes #3 