### PR TITLE
kustomize/advanced: kustomize v5 compatibility

### DIFF
--- a/kustomize/advanced/kustomization.yaml
+++ b/kustomize/advanced/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base/
-patchesStrategicMerge:
-  - use-advanced.patch.yaml
+patches:
+  - path: use-advanced.patch.yaml

--- a/kustomize/advanced/kustomization.yaml
+++ b/kustomize/advanced/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base/
-patches:
+patchesStrategicMerge:
   - use-advanced.patch.yaml


### PR DESCRIPTION
The bare `patches` attribute was apparently a legacy thing, which v5 attributed new meaning to; see kubernetes-sigs/kustomize#4911.

`patchesStrategicMerge` should work on both v4 and v5.